### PR TITLE
Fixing very spaced out lists

### DIFF
--- a/sphinx_holoviz_theme/static/css/main.css_t
+++ b/sphinx_holoviz_theme/static/css/main.css_t
@@ -1827,16 +1827,6 @@ dt a.headerlink {
     vertical-align: inherit
 }
 
-.simple {
-    display: inline-block;
-    margin-bottom: .75em;
-    padding-left: 1.5em
-}
-
-.simple ~ p {
-    clear: both
-}
-
 .mosaic.docs-home {
     margin-top: 2em
 }


### PR DESCRIPTION
Before:

<img width="744" alt="Screen Shot 2019-11-14 at 5 04 50 PM" src="https://user-images.githubusercontent.com/4806877/68900012-eadd7d80-0700-11ea-8715-4b213f436be9.png">

After:
<img width="712" alt="Screen Shot 2019-11-14 at 5 04 41 PM" src="https://user-images.githubusercontent.com/4806877/68900021-f0d35e80-0700-11ea-9cb1-c00d17ab2abb.png">
